### PR TITLE
Fix tests for Dist::Zilla 6.007.

### DIFF
--- a/corpus/dist.ini
+++ b/corpus/dist.ini
@@ -10,7 +10,7 @@ copyright_year   = 2009
 [AutoPrereqsFast]
 extra_scanners = Moose
 skip = ^DZPA::Skip
-[MetaYAML]
+[MetaJSON]
 version = 2
 
 [Encoding]

--- a/t/basic.t
+++ b/t/basic.t
@@ -2,17 +2,19 @@
 use strict;
 use warnings;
 
-use Test::More 0.88;
+use Test::More tests => 3;
+
 
 use Test::DZil;
-use YAML::Tiny;
+use JSON::Tiny qw(decode_json);
+use File::Slurper qw(read_text);
 
 sub build_meta {
   my $tzil = shift;
 
   $tzil->build;
 
-  YAML::Tiny->new->read($tzil->tempdir->file('build/META.yml'))->[0];
+  return decode_json(read_text($tzil->tempdir->path('build/META.json')));
 }
 
 my $tzil = Builder->from_config(
@@ -64,7 +66,7 @@ $tzil = Builder->from_config(
         qw(GatherDir ExecDir),
         [ AutoPrereqsFast => { skip             => '^DZPA::Skip',
                                configure_finder => ':IncModules' } ],
-        [ MetaYAML => { version => 2 } ],
+        [ MetaJSON => { version => 2 } ],
       ),
       'source/inc/DZPA.pm' => "use DZPA::NotInDist;\n use DZPA::Configure;\n",
     },


### PR DESCRIPTION
In 6.007 META.yaml was locked down to version 1.4 of the spec, regardless
of what was in dist.ini.  Used META.json to avoid this.
